### PR TITLE
docs: clarify planning guide and add cockpit-apt repo

### DIFF
--- a/PROJECT_PLANNING_GUIDE.md
+++ b/PROJECT_PLANNING_GUIDE.md
@@ -90,6 +90,11 @@ For each major component, create tasks with:
 - Caveats and considerations
 - Dependencies on other tasks
 
+**Format Guidelines:**
+- DO NOT include time estimates (no weeks, months, days, hours)
+- Focus on task dependencies and order, not duration
+- Keep task descriptions actionable and clear
+
 **Purpose:** This temporary file helps plan and discuss the implementation before creating GitHub issues.
 
 **Human reviews and approves:** Review TASKS.md and request changes if needed before proceeding to create issues
@@ -280,6 +285,7 @@ You: Approve or adjust
 - Review critical code paths manually
 - Update docs/ files to reflect actual implementation
 - Use semantic versioning for releases
+- Avoid time estimates in planning documents (focus on dependencies and order)
 
 ### Don't
 

--- a/run
+++ b/run
@@ -37,6 +37,7 @@ declare -A REPOS=(
   ["runtipi-docker-service"]="git@github.com:hatlabs/runtipi-docker-service.git main"
   ["avnav-docker"]="git@github.com:hatlabs/avnav-docker.git main"
   ["opencpn-docker"]="git@github.com:hatlabs/opencpn-docker.git main"
+  ["cockpit-apt"]="git@github.com:hatlabs/cockpit-apt.git main"
 )
 
 ################################################################################


### PR DESCRIPTION
## Summary

Minor updates to project planning guide and workspace configuration.

## Changes

### PROJECT_PLANNING_GUIDE.md
- Added format guidelines to Step 3 (TASKS.md creation)
- Emphasize avoiding time estimates in task planning
- Focus on task dependencies and order instead of duration
- Added guideline to best practices section

### run script
- Added cockpit-apt repository to workspace repositories list
- Enables `./run repos:clone` and other repo management commands for cockpit-apt

## Rationale

These changes improve the planning guide based on recent experience:
1. Time estimates are often inaccurate and create false expectations
2. Task dependencies and order are more valuable for planning
3. The cockpit-apt repository is part of the workspace and should be managed by the run script

🤖 Generated with [Claude Code](https://claude.com/claude-code)