### PR TITLE
docs: update references to LIFE_WITH_CLAUDE.md and refine workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 **IMPORTANT**: When using Claude Code or other AI assistants, always work from this workspace repository, not individual sub-repos. The full context enables better code understanding and implementation quality.
 
 **Development Workflows**: See `docs/` folder:
-- `docs/HUMAN_DEVELOPMENT_GUIDANCE.md` - Quick start for human developers
+- `docs/LIFE_WITH_CLAUDE.md` - Quick start for human developers
 - `docs/IMPLEMENTATION_CHECKLIST.md` - Implementation checklist
 - `docs/DEVELOPMENT_WORKFLOW.md` - Detailed Claude Code workflows
 - `docs/PROJECT_PLANNING_GUIDE.md` - Project planning process

--- a/docs/PROJECT_PLANNING_GUIDE.md
+++ b/docs/PROJECT_PLANNING_GUIDE.md
@@ -1,7 +1,5 @@
 # Claude Code Project Planning Guide
 
-**Last modified:** 2025-11-16
-
 This document describes the project planning and development workflow for Claude Code-driven projects backed by GitHub repositories.
 
 ## Philosophy
@@ -20,8 +18,6 @@ This document describes the project planning and development workflow for Claude
   - Branch targeting criteria: `main` (default branch)
   - Require a pull request before merging
   - Block force pushes
-  - Automatically request Copilot code review
-  - Copilot sub-option: Review new pushes
 
 
 ## Project Structure
@@ -107,8 +103,6 @@ After reviewing and refining TASKS.md:
 
 **Claude Code creates:** GitHub issues for each task
 
-**IMPORTANT:** Use the issue templates in `.github/ISSUE_TEMPLATE/` when available. These templates ensure proper workflow guidance.
-
 **Issue format (if not using template):**
 ```
 Title: [Brief, clear description]
@@ -183,7 +177,8 @@ EOF
   --label "type:feature"
 ```
 
-**Important:** Each repository should have `docs/IMPLEMENTATION_CHECKLIST.md` and all issues must mandate following it during implementation.
+**Important:** Each repository should have `docs/IMPLEMENTATION_CHECKLIST.md` and
+it should be inserted in the issue body of every new issue.
 
 **After issue creation:** Delete TASKS.md as it has served its purpose (or archive outside repository if historical reference is needed)
 
@@ -232,10 +227,9 @@ Claude Code: Closes issue with summary of changes
 
 ### Iteration Patterns
 
-**All development iteration happens through direct conversation**, not through GitHub comments:
+**All development iteration happens through direct conversation**:
 
 - Quick fixes: Just tell Claude Code what to change
-- Code review feedback: Discuss directly, no need to document in issue
 - Design discussions: Talk it through, update docs/ files if needed
 
 ### Ad-hoc Work


### PR DESCRIPTION
## Summary

Update workspace documentation references and refine workflow guidance:

1. Update `AGENTS.md` to reference `LIFE_WITH_CLAUDE.md` instead of deprecated `HUMAN_DEVELOPMENT_GUIDANCE.md`
2. Refine `docs/PROJECT_PLANNING_GUIDE.md` by removing outdated metadata and references

## Changes

**AGENTS.md:**
- Update reference from HUMAN_DEVELOPMENT_GUIDANCE.md → LIFE_WITH_CLAUDE.md

**docs/PROJECT_PLANNING_GUIDE.md:**
- Remove "Last modified" date (git history is source of truth)
- Remove Copilot-specific branch protection rules
- Remove reference to deprecated issue templates
- Clarify IMPLEMENTATION_CHECKLIST.md usage in issues

## Related

- Follows halos-distro/pull/24 (LIFE_WITH_CLAUDE.md introduction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>