### PR TITLE
docs: clarify Claude pricing and plan guidance

### DIFF
--- a/docs/LIFE_WITH_CLAUDE.md
+++ b/docs/LIFE_WITH_CLAUDE.md
@@ -152,7 +152,7 @@ There is one more crucial step: code review! Always have Claude review their own
 
 ## Plan and Models to Use
 
-The increased productivity, unfortunately, comes at a cost. The regular USD 20 /month Claude Pro plan is only good for maybe two hours of daily development work, and it will also consume the weekly quota in no time. The USD 100 /month Claude Max plan is sufficient for full-time development work, as long as you don't try to run multiple sessions in parallel.
+The increased productivity, unfortunately, comes at a cost. The regular USD 20 /month Claude Pro plan is good for maybe one or two hours of daily development work, and it will also consume the weekly quota in no time. It is still usable for occasional use, though. The USD 100 /month Claude Max plan is sufficient for full-time development work, as long as you don't try to run multiple sessions in parallel. It is also possible to pay for extra usage if needed, so if you only need a little more than what Claude Pro offers, you don't need to jump to Max immediately.
 
 The output quality also depends on the LLM model used. Anthropic's Claude Sonnet 4.5 is a capable model. I have not found much improvement when using their best model, Claude Opus 4.1. Opus is also five times as expensive.
 


### PR DESCRIPTION
## Summary

Improve clarity around Claude Pro and Claude Max pricing options to help users better understand plan selection.

## Changes

- Clarify that Claude Pro is good for one or two hours of daily development work
- Note that Claude Pro is still usable for occasional use cases
- Explain Claude Max plan flexibility and potential migration paths
- Add information about paying for extra usage as an alternative to upgrading to Max immediately

## Context

These clarifications help users make informed decisions about which plan meets their needs, whether they're casual users, occasional developers, or full-time users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>