### PR TITLE
feat: Add cockpit-branding-halos repository to workspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,13 +28,13 @@ This workspace manages multiple independent repositories. While each repository 
 
 ```
 halos-distro/
-├── halos-pi-gen/                  # Image builder (submodule)
-├── runtipi-marine-app-store/      # Marine app store (submodule)
-├── runtipi-docker-service/        # Runtipi Debian package
-├── apt.hatlabs.fi/                # Custom APT repo (submodule)
-├── cockpit-apt/                   # Cockpit APT package manager (Phase 1)
-├── container-packaging-tools/     # Container package generator (Phase 1)
-└── halos-marine-containers/       # Marine app definitions + store (Phase 1)
+├── halos-pi-gen/                  # Image builder
+├── runtipi-marine-app-store/      # Marine app store
+├── apt.hatlabs.fi/                # Custom APT repo
+├── cockpit-apt/                   # Cockpit APT package manager
+├── cockpit-branding-halos/        # Cockpit HaLOS branding package
+├── container-packaging-tools/     # Container package generator
+└── halos-marine-containers/       # Marine app definitions + store
 ```
 
 **Each repository has its own AGENTS.md** - read the appropriate one for detailed context.

--- a/run
+++ b/run
@@ -38,6 +38,7 @@ declare -A REPOS=(
   ["avnav-docker"]="git@github.com:hatlabs/avnav-docker.git main"
   ["opencpn-docker"]="git@github.com:hatlabs/opencpn-docker.git main"
   ["cockpit-apt"]="git@github.com:hatlabs/cockpit-apt.git main"
+  ["cockpit-branding-halos"]="git@github.com:hatlabs/cockpit-branding-halos.git main"
 )
 
 ################################################################################


### PR DESCRIPTION
## Summary

Add the new `cockpit-branding-halos` repository to the halos-distro workspace management system.

## Changes

- ✅ Add `cockpit-branding-halos` to `REPOS` array in `run` script
- ✅ Update `AGENTS.md` structure diagram to include new repository

## New Repository

The `cockpit-branding-halos` package provides custom HaLOS branding for the Cockpit web interface.

**Repository**: https://github.com/hatlabs/cockpit-branding-halos

The repository includes:
- Debian package files for cockpit-branding-halos
- Docker-based build system
- Complete documentation (SPEC.md, ARCHITECTURE.md, AGENTS.md)
- Branding assets (CSS, logos, icons)

## Testing

```bash
# Clone the new repository
./run repos:clone

# Verify it was cloned
ls -la cockpit-branding-halos/
```

Related to #27