### PR TITLE
feat: Add halos-metapackages repository to workspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ halos-distro/
 ├── apt.hatlabs.fi/                # Custom APT repo
 ├── cockpit-apt/                   # Cockpit APT package manager
 ├── cockpit-branding-halos/        # Cockpit HaLOS branding package
+├── halos-metapackages/            # HaLOS metapackages (halos, halos-marine)
 ├── container-packaging-tools/     # Container package generator
 └── halos-marine-containers/       # Marine app definitions + store
 ```

--- a/run
+++ b/run
@@ -39,6 +39,7 @@ declare -A REPOS=(
   ["opencpn-docker"]="git@github.com:hatlabs/opencpn-docker.git main"
   ["cockpit-apt"]="git@github.com:hatlabs/cockpit-apt.git main"
   ["cockpit-branding-halos"]="git@github.com:hatlabs/cockpit-branding-halos.git main"
+  ["halos-metapackages"]="git@github.com:hatlabs/halos-metapackages.git main"
 )
 
 ################################################################################


### PR DESCRIPTION
## Summary

Add the halos-metapackages repository to the halos-distro workspace.

## Changes

- ✅ Add `halos-metapackages` to `REPOS` array in `run` script  
- ✅ Update `AGENTS.md` structure diagram

## New Repository

**Repository**: https://github.com/hatlabs/halos-metapackages

Provides two metapackages:
- **`halos`** - Base HaLOS system (Cockpit + tools)
- **`halos-marine`** - Marine variant (depends on halos + marine packages)

## Testing

```bash
# Clone the new repository
./run repos:clone

# Verify it was cloned
ls -la halos-metapackages/
```

Closes #28