### PR TITLE
docs: add halos-core-containers to workspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ halos-distro/
 ├── halos-metapackages/            # HaLOS metapackages (halos, halos-marine)
 ├── container-packaging-tools/     # Container package generator
 ├── halos-marine-containers/       # Marine app definitions + store
+├── halos-core-containers/         # Core app definitions (Homarr dashboard)
 └── halos-imported-containers/     # Auto-imported apps from CasaOS, Runtipi, etc.
 ```
 

--- a/run
+++ b/run
@@ -41,6 +41,7 @@ declare -A REPOS=(
   ["cockpit-branding-halos"]="git@github.com:hatlabs/cockpit-branding-halos.git main"
   ["cockpit-networkmanager-halos"]="git@github.com:hatlabs/cockpit-networkmanager-halos.git main"
   ["halos-metapackages"]="git@github.com:hatlabs/halos-metapackages.git main"
+  ["halos-core-containers"]="git@github.com:hatlabs/halos-core-containers.git main"
 )
 
 ################################################################################


### PR DESCRIPTION
## Summary

- Add halos-core-containers repository to the workspace configuration
- Add to REPOS array in run script for automated cloning
- Add to structure diagram in AGENTS.md

This PR completes the workspace integration for the new halos-core-containers repository created in https://github.com/hatlabs/halos-core-containers

Closes #44

## Test plan

- [ ] Run `./run repos:clone` to verify the new repo can be cloned
- [ ] Verify structure diagram in AGENTS.md is properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)