### PR TITLE
docs: add lefthook setup instructions to workspace docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # HaLOS Workspace - Agentic Coding Hub
 
-**LAST MODIFIED**: 2025-12-10
+**LAST MODIFIED**: 2025-12-17
 
 **Document Purpose**: Central workspace for agentic coding with Claude Code and other AI assistants. This workspace provides full context across all HaLOS repositories for optimal AI-assisted development.
 
@@ -25,6 +25,8 @@ This workspace manages multiple independent repositories. While each repository 
 **MANDATORY**: PRs must ALWAYS have all checks passing before merging. No matter what.
 
 **PR Reviews**: When reviewing pull requests, always post review comments directly on the PR itself using `gh pr comment`. This ensures feedback is visible to all stakeholders and preserved in the project history.
+
+**Pre-commit Hooks**: Repositories use [lefthook](https://github.com/evilmartians/lefthook) for pre-commit hooks. After cloning, install hooks with `./run hooks-install`. See `docs/LIFE_WITH_CLAUDE.md` for details.
 
 ## Structure
 

--- a/docs/LIFE_WITH_CLAUDE.md
+++ b/docs/LIFE_WITH_CLAUDE.md
@@ -186,6 +186,30 @@ I have no strong opinion on MCPs at this point. I do have [ck-search](https://gi
 
 Hooks are user-defined shell commands that can be set to execute at specific points during Claude's operation. They can, for example, be used to validate commands before execution. I have not used them much, except for one thing: `git add -A` is something Claude likes to do, and it pulls in unwanted cruft. I asked Claude to create a hook to forbid that command, and voila! Problem solved.
 
+## Git Pre-commit Hooks with Lefthook
+
+To catch formatting and linting issues before they reach CI, HaLOS repositories use [lefthook](https://github.com/evilmartians/lefthook) for git pre-commit hooks. This ensures CI checks don't fail due to formatting issues that should have been caught locally.
+
+**One-time Setup:**
+
+```bash
+# Install lefthook
+brew install lefthook
+```
+
+**Per-repository Setup:**
+
+After cloning any HaLOS repository that has a `lefthook.yml`, install the hooks:
+
+```bash
+./run hooks-install
+```
+
+This enables pre-commit hooks that run format and lint checks matching what CI runs. To skip hooks when needed (e.g., WIP commits):
+
+```bash
+git commit --no-verify -m "WIP: message"
+```
 
 ## References
 


### PR DESCRIPTION
## Summary

- Add Git Pre-commit Hooks section to `LIFE_WITH_CLAUDE.md` with one-time setup and per-repo setup instructions
- Add Pre-commit Hooks note to `AGENTS.md` Git Workflow Policy section

## Test plan

- [x] Verified documentation is clear and accurate
- [x] Links to relevant repos are correct

Part of #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)