### PR TITLE
chore: migrate org references from hatlabs to halos-org

### DIFF
--- a/META-PLANNING.md
+++ b/META-PLANNING.md
@@ -9,7 +9,7 @@
 This document coordinates the multi-component HaLOS Cockpit development effort. It provides high-level architecture decisions, phase planning, and pointers to detailed component designs.
 
 **For implementation details**, see component-specific DESIGN.md files linked below.
-**For progress tracking**, see [GitHub Issues](https://github.com/hatlabs/halos-distro/issues) and [Project Board](https://github.com/orgs/hatlabs/projects/1).
+**For progress tracking**, see [GitHub Issues](https://github.com/halos-org/halos-distro/issues) and [Project Board](https://github.com/orgs/halos-org/projects/1).
 
 ## Vision: Browser-Based, Unified Administration
 
@@ -65,16 +65,16 @@ halos-distro/                      # Workspace coordinator (this repo)
 
 1. **halos-marine-containers** - Marine app definitions and store
    - [DESIGN.md](halos-marine-containers/docs/DESIGN.md) - App/store format, build process
-   - [Issue #14](https://github.com/hatlabs/halos-distro/issues/14) - Implementation tracking
+   - [Issue #14](https://github.com/halos-org/halos-distro/issues/14) - Implementation tracking
 
 2. **container-packaging-tools** - Package generation tooling
    - [DESIGN.md](container-packaging-tools/docs/DESIGN.md) - Tool architecture, templates
-   - [Issue #15](https://github.com/hatlabs/halos-distro/issues/15) - Implementation tracking
+   - [Issue #15](https://github.com/halos-org/halos-distro/issues/15) - Implementation tracking
 
 3. **cockpit-apt** - Store filtering and repository management
    - [CONTAINER_STORE_DESIGN.md](cockpit-apt/docs/CONTAINER_STORE_DESIGN.md) - UI/backend design
    - [ADR-001-container-store.md](cockpit-apt/docs/ADR-001-container-store.md) - Architecture decision
-   - [Issue #13](https://github.com/hatlabs/halos-distro/issues/13) - Implementation tracking
+   - [Issue #13](https://github.com/halos-org/halos-distro/issues/13) - Implementation tracking
 
 ### Phase 2+ Components (Concept)
 
@@ -197,9 +197,9 @@ halos-distro/                      # Workspace coordinator (this repo)
 
 ## GitHub Tracking
 
-**Project Board**: [HaLOS Development](https://github.com/orgs/hatlabs/projects/1)
-**Milestones**: [View all milestones](https://github.com/hatlabs/halos-distro/milestones)
-**Issues**: [View open issues](https://github.com/hatlabs/halos-distro/issues)
+**Project Board**: [HaLOS Development](https://github.com/orgs/halos-org/projects/1)
+**Milestones**: [View all milestones](https://github.com/halos-org/halos-distro/milestones)
+**Issues**: [View open issues](https://github.com/halos-org/halos-distro/issues)
 
 ### Issue Labels
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-- Download the image you want at https://github.com/hatlabs/halos-pi-gen/releases/latest
+- Download the image you want at https://github.com/halos-org/halos-pi-gen/releases/latest
 - Flash to SSD or SD-card
 - Boot the device
 - Access https://halos.local (assuming wired Ethernet connection)
@@ -99,7 +99,7 @@ Halos comes in multiple variants to suit different hardware and use cases:
 
 ### 1. Download the Image
 
-Download your chosen image from the [Halos releases page](https://github.com/hatlabs/halos-pi-gen/releases).
+Download your chosen image from the [Halos releases page](https://github.com/halos-org/halos-pi-gen/releases).
 
 ### 2. Flash to SD Card or SSD
 
@@ -237,8 +237,8 @@ This can be done via the Cockpit terminal.
 
 ### Get Involved
 
-- **Discussions**: [GitHub Discussions](https://github.com/hatlabs/halos-distro/discussions) - Ask questions, share ideas, and connect with other users
-- **Follow Progress**: [GitHub Issues](https://github.com/hatlabs/halos-distro/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/halos-org/halos-distro/discussions) - Ask questions, share ideas, and connect with other users
+- **Follow Progress**: [GitHub Issues](https://github.com/halos-org/halos-distro/issues)
 - **Provide Feedback**: Open issues with feature requests or bug reports
 - **Contribute**: See individual component repositories for contribution guidelines
 

--- a/docs/LIFE_WITH_CLAUDE.md
+++ b/docs/LIFE_WITH_CLAUDE.md
@@ -91,7 +91,7 @@ The project structure should follow the same workspace approach as described
 above. (Of course, if you want to use an actual monorepo, no-one is stopping you!)
 
 Create a `docs/` directory in the workspace root. This is where all
-documentation files go. Copy the policy and workflow documents from another repo such as [halos-distro](https://github.com/hatlabs/halos-distro) to get started quickly.
+documentation files go. Copy the policy and workflow documents from another repo such as [halos-distro](https://github.com/halos-org/halos-distro) to get started quickly.
 
 You should at least have the following files:
 - [PROJECT_PLANNING_GUIDE.md](PROJECT_PLANNING_GUIDE.md)

--- a/run
+++ b/run
@@ -31,17 +31,17 @@ readonly SCRIPT="$PROJECT_ROOT/$(basename "$0")"
 # Repository Definitions
 
 declare -A REPOS=(
-  ["halos-pi-gen"]="git@github.com:hatlabs/halos-pi-gen.git main"
+  ["halos-pi-gen"]="git@github.com:halos-org/halos-pi-gen.git main"
   ["apt.hatlabs.fi"]="git@github.com:hatlabs/apt.hatlabs.fi.git main"
   ["runtipi-marine-app-store"]="git@github.com:hatlabs/runtipi-marine-app-store.git main"
   ["runtipi-docker-service"]="git@github.com:hatlabs/runtipi-docker-service.git main"
   ["avnav-docker"]="git@github.com:hatlabs/avnav-docker.git main"
-  ["opencpn-docker"]="git@github.com:hatlabs/opencpn-docker.git main"
-  ["cockpit-apt"]="git@github.com:hatlabs/cockpit-apt.git main"
-  ["cockpit-branding-halos"]="git@github.com:hatlabs/cockpit-branding-halos.git main"
-  ["cockpit-networkmanager-halos"]="git@github.com:hatlabs/cockpit-networkmanager-halos.git main"
-  ["halos-metapackages"]="git@github.com:hatlabs/halos-metapackages.git main"
-  ["halos-core-containers"]="git@github.com:hatlabs/halos-core-containers.git main"
+  ["opencpn-docker"]="git@github.com:halos-org/opencpn-docker.git main"
+  ["cockpit-apt"]="git@github.com:halos-org/cockpit-apt.git main"
+  ["halos-cockpit-config"]="git@github.com:halos-org/halos-cockpit-config.git main"
+  ["cockpit-networkmanager-halos"]="git@github.com:halos-org/cockpit-networkmanager-halos.git main"
+  ["halos-metapackages"]="git@github.com:halos-org/halos-metapackages.git main"
+  ["halos-core-containers"]="git@github.com:halos-org/halos-core-containers.git main"
 )
 
 ################################################################################


### PR DESCRIPTION
## Summary

- Update all GitHub organization references from `hatlabs` to `halos-org` for transferred repositories
- CI workflow references, `run` script clone URLs, documentation links, and other org-specific URLs
- Fix stale `cockpit-branding-halos` repo name to `halos-cockpit-config` in `run` script

Part of the HaLOS org migration from `hatlabs` to `halos-org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)