### PR TITLE
chore: update references for repo rename halos-distro → halos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ This workspace manages multiple independent repositories. While each repository 
 ## Structure
 
 ```
-halos-distro/
+halos/
 ├── halos-pi-gen/                  # Image builder
 ├── apt.hatlabs.fi/                # Custom APT repo
 ├── cockpit-apt/                   # Cockpit APT package manager
@@ -120,4 +120,4 @@ git pull origin main
 cd ..
 ```
 
-Each repository is managed independently. The halos-distro workspace tracks only shared documentation and convenience scripts.
+Each repository is managed independently. The halos workspace tracks only shared documentation and convenience scripts.

--- a/META-PLANNING.md
+++ b/META-PLANNING.md
@@ -9,7 +9,7 @@
 This document coordinates the multi-component HaLOS Cockpit development effort. It provides high-level architecture decisions, phase planning, and pointers to detailed component designs.
 
 **For implementation details**, see component-specific DESIGN.md files linked below.
-**For progress tracking**, see [GitHub Issues](https://github.com/halos-org/halos-distro/issues) and [Project Board](https://github.com/orgs/halos-org/projects/1).
+**For progress tracking**, see [GitHub Issues](https://github.com/halos-org/halos/issues) and [Project Board](https://github.com/orgs/halos-org/projects/1).
 
 ## Vision: Browser-Based, Unified Administration
 
@@ -47,7 +47,7 @@ This document coordinates the multi-component HaLOS Cockpit development effort. 
 ### Repository Structure
 
 ```
-halos-distro/                      # Workspace coordinator (this repo)
+halos/                             # Workspace coordinator (this repo)
 ├── docs/                          # Cross-component design docs
 ├── halos-marine-containers/       # Marine apps + store definition
 │   └── docs/DESIGN.md
@@ -65,16 +65,16 @@ halos-distro/                      # Workspace coordinator (this repo)
 
 1. **halos-marine-containers** - Marine app definitions and store
    - [DESIGN.md](halos-marine-containers/docs/DESIGN.md) - App/store format, build process
-   - [Issue #14](https://github.com/halos-org/halos-distro/issues/14) - Implementation tracking
+   - [Issue #14](https://github.com/halos-org/halos/issues/14) - Implementation tracking
 
 2. **container-packaging-tools** - Package generation tooling
    - [DESIGN.md](container-packaging-tools/docs/DESIGN.md) - Tool architecture, templates
-   - [Issue #15](https://github.com/halos-org/halos-distro/issues/15) - Implementation tracking
+   - [Issue #15](https://github.com/halos-org/halos/issues/15) - Implementation tracking
 
 3. **cockpit-apt** - Store filtering and repository management
    - [CONTAINER_STORE_DESIGN.md](cockpit-apt/docs/CONTAINER_STORE_DESIGN.md) - UI/backend design
    - [ADR-001-container-store.md](cockpit-apt/docs/ADR-001-container-store.md) - Architecture decision
-   - [Issue #13](https://github.com/halos-org/halos-distro/issues/13) - Implementation tracking
+   - [Issue #13](https://github.com/halos-org/halos/issues/13) - Implementation tracking
 
 ### Phase 2+ Components (Concept)
 
@@ -198,8 +198,8 @@ halos-distro/                      # Workspace coordinator (this repo)
 ## GitHub Tracking
 
 **Project Board**: [HaLOS Development](https://github.com/orgs/halos-org/projects/1)
-**Milestones**: [View all milestones](https://github.com/halos-org/halos-distro/milestones)
-**Issues**: [View open issues](https://github.com/halos-org/halos-distro/issues)
+**Milestones**: [View all milestones](https://github.com/halos-org/halos/milestones)
+**Issues**: [View open issues](https://github.com/halos-org/halos/issues)
 
 ### Issue Labels
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Halos Raspberry Pi OS Distribution
 
-**[Documentation](https://docs.halos.fi)** | **[Website](https://halos.fi)** | **[Downloads](https://github.com/hatlabs/halos-pi-gen/releases/latest)**
+**[Documentation](https://docs.halos.fi)** | **[Website](https://halos.fi)** | **[Downloads](https://github.com/halos-org/halos-pi-gen/releases/latest)**
 
 ## TL;DR
 
@@ -239,8 +239,8 @@ This can be done via the Cockpit terminal.
 
 ### Get Involved
 
-- **Discussions**: [GitHub Discussions](https://github.com/halos-org/halos-distro/discussions) - Ask questions, share ideas, and connect with other users
-- **Follow Progress**: [GitHub Issues](https://github.com/halos-org/halos-distro/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/halos-org/halos/discussions) - Ask questions, share ideas, and connect with other users
+- **Follow Progress**: [GitHub Issues](https://github.com/halos-org/halos/issues)
 - **Provide Feedback**: Open issues with feature requests or bug reports
 - **Contribute**: See individual component repositories for contribution guidelines
 

--- a/docs/LIFE_WITH_CLAUDE.md
+++ b/docs/LIFE_WITH_CLAUDE.md
@@ -91,7 +91,7 @@ The project structure should follow the same workspace approach as described
 above. (Of course, if you want to use an actual monorepo, no-one is stopping you!)
 
 Create a `docs/` directory in the workspace root. This is where all
-documentation files go. Copy the policy and workflow documents from another repo such as [halos-distro](https://github.com/halos-org/halos-distro) to get started quickly.
+documentation files go. Copy the policy and workflow documents from another repo such as [halos](https://github.com/halos-org/halos) to get started quickly.
 
 You should at least have the following files:
 - [PROJECT_PLANNING_GUIDE.md](PROJECT_PLANNING_GUIDE.md)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,4 +1,4 @@
-# Lefthook configuration for halos-distro workspace
+# Lefthook configuration for halos workspace
 # Install with: lefthook install
 
 pre-commit:

--- a/run
+++ b/run
@@ -2,7 +2,7 @@
 #
 # usage: ./run command [argument ...]
 #
-# Commands for managing the halos-distro workspace.
+# Commands for managing the halos workspace.
 #
 # See https://death.andgravity.com/run-sh
 # for an explanation of how it works and why it's useful.


### PR DESCRIPTION
## Summary
- Update all `halos-distro` references to `halos` across workspace docs, scripts, and config
- Fix stale `hatlabs/halos-pi-gen` link in README.md → `halos-org/halos-pi-gen`

## Test plan
- [ ] Verify all links in AGENTS.md, README.md, META-PLANNING.md resolve correctly
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)