### PR TITLE
chore: workspace docs hook + dev-deps task + docs cleanup

### DIFF
--- a/.claude/hooks/workspace-docs-reminder.sh
+++ b/.claude/hooks/workspace-docs-reminder.sh
@@ -3,8 +3,9 @@
 # Fires only for files at <workspace-root>/docs/...; skips sub-repo docs/.
 # Non-blocking: always exits 0. Errors are silenced so a misbehaving hook
 # never fails an agent's tool call.
+#
+# Requires: jq (silently no-ops if missing — install via `./run install-dev-deps`).
 
-set +e
 exec 2>/dev/null
 
 input=$(cat)
@@ -14,8 +15,10 @@ file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.p
 [ -z "$file_path" ] && exit 0
 
 # Workspace root = two directories up from this script's location.
-script_dir=$(cd "$(dirname "$0")" && pwd) || exit 0
-workspace_root=$(cd "$script_dir/../.." && pwd) || exit 0
+# Use `pwd -P` so a workspace cloned at a symlinked path matches the physical
+# path the tool reports in file_path.
+script_dir=$(cd "$(dirname "$0")" && pwd -P) || exit 0
+workspace_root=$(cd "$script_dir/../.." && pwd -P) || exit 0
 
 case "$file_path" in
   /*) abs_path=$file_path ;;

--- a/.claude/hooks/workspace-docs-reminder.sh
+++ b/.claude/hooks/workspace-docs-reminder.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# PostToolUse reminder for writes under the workspace's top-level docs/.
+# Fires only for files at <workspace-root>/docs/...; skips sub-repo docs/.
+# Non-blocking: always exits 0. Errors are silenced so a misbehaving hook
+# never fails an agent's tool call.
+
+set +e
+exec 2>/dev/null
+
+input=$(cat)
+[ -z "$input" ] && exit 0
+
+file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.path // empty')
+[ -z "$file_path" ] && exit 0
+
+# Workspace root = two directories up from this script's location.
+script_dir=$(cd "$(dirname "$0")" && pwd) || exit 0
+workspace_root=$(cd "$script_dir/../.." && pwd) || exit 0
+
+case "$file_path" in
+  /*) abs_path=$file_path ;;
+  *)  abs_path="$workspace_root/$file_path" ;;
+esac
+
+case "$abs_path" in
+  "$workspace_root"/docs/*) ;;
+  *) exit 0 ;;
+esac
+
+# Defensive: confirm the file's git root is the workspace, not a nested repo.
+file_dir=$(dirname "$abs_path")
+[ -d "$file_dir" ] || file_dir=$workspace_root
+file_git_root=$(git -C "$file_dir" rev-parse --show-toplevel 2>/dev/null) || exit 0
+[ "$file_git_root" = "$workspace_root" ] || exit 0
+
+reminder="Workspace docs/ reminder (file: $abs_path)
+- This is the PUBLIC halos-org/halos repo. Do NOT leak names, designs, or even the existence of private repos here.
+- Docs about a specific repo belong in THAT repo's docs/. The workspace docs/ is for cross-repo, public concerns only.
+- If the just-written file violates either rule, undo it now (delete, or move into the right repo) before the user sees it."
+
+jq -n --arg msg "$reminder" '{
+  systemMessage: $msg,
+  hookSpecificOutput: {
+    hookEventName: "PostToolUse",
+    additionalContext: $msg
+  }
+}'
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/workspace-docs-reminder.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 CLAUDE.local.md
+.claude/settings.local.json
 
 # Sub-repositories (managed by ./run script)
 halos-pi-gen/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 - `docs/DEVELOPMENT_WORKFLOW.md` - Detailed Claude Code workflows
 - `docs/PROJECT_PLANNING_GUIDE.md` - Project planning process
 - `docs/HOSTNAME_POLICY.md` - Policy on hard-coded hostname references
+- `docs/solutions/` - Documented solutions to past problems (bugs, best practices, workflow patterns), with YAML frontmatter for searchability; relevant when implementing or debugging in documented areas
 
 ## ⛔ Test Device Policy
 
@@ -99,10 +100,10 @@ When configuring CI workflows, always use the correct `apt-repository` input for
 
 ```bash
 # Clone all component repositories
-./run repos:clone
+./run clone-repos
 
 # Update all repositories
-./run repos:pull-all-main
+./run pull-all-main
 
 # Build an image
 cd halos-pi-gen
@@ -120,10 +121,10 @@ cd halos-pi-gen
 
 ```bash
 # Update all repositories to latest main/halos branches
-./run repos:pull-all-main
+./run pull-all-main
 
 # Check status of all repositories
-./run repos:status
+./run show-status
 
 # Work in a specific repository
 cd halos-pi-gen

--- a/README.md
+++ b/README.md
@@ -275,13 +275,13 @@ Each repository is independently managed. The `./run` script provides convenienc
 
 ```bash
 # Clone all component repositories
-./run repos:clone
+./run clone-repos
 
 # Update all repositories to latest
-./run repos:pull-all-main
+./run pull-all-main
 
 # Check status of all repositories
-./run repos:status
+./run show-status
 
 # Build an image (requires Docker)
 cd halos-pi-gen

--- a/run
+++ b/run
@@ -133,6 +133,40 @@ function show-status {
 ################################################################################
 # Setup Commands
 
+function install-dev-deps {
+  #@ Install workspace-level development dependencies (jq, lefthook, gh)
+  #@ Category: Setup
+  local -a deps=(jq lefthook gh)
+  local -a missing=()
+  for dep in "${deps[@]}"; do
+    if ! command -v "$dep" &>/dev/null; then
+      missing+=("$dep")
+    fi
+  done
+
+  if [ ${#missing[@]} -eq 0 ]; then
+    echo "✅ All dev dependencies already installed: ${deps[*]}"
+    return 0
+  fi
+
+  echo "📦 Missing: ${missing[*]}"
+
+  if command -v brew &>/dev/null; then
+    echo "🍺 Installing via Homebrew..."
+    brew install "${missing[@]}"
+  elif command -v apt-get &>/dev/null; then
+    echo "📦 Installing via apt..."
+    sudo apt-get update
+    sudo apt-get install -y "${missing[@]}"
+  else
+    echo "❌ No supported package manager found (brew or apt-get)."
+    echo "   Install manually: ${missing[*]}"
+    return 1
+  fi
+
+  echo "✅ Dev dependencies installed"
+}
+
 function install-hooks {
   #@ Install pre-commit hooks using lefthook
   #@ Category: Setup


### PR DESCRIPTION
## Summary
A small mix-tape of related workspace-tooling improvements, all kicked off by the leak-prevention hook in commit 1.

### 1. Workspace docs/ reminder hook (`chore: add workspace docs/ reminder hook`)
Non-blocking PostToolUse hook (`.claude/hooks/workspace-docs-reminder.sh`) that fires when an agent writes under the workspace's top-level `docs/` directory — but not when writing to a sub-repo's `docs/`. Reminds the agent that:

- This is the **public** `halos-org/halos` repo — don't leak names, designs, or even the existence of private repos here.
- Per-repo docs belong in **that repo's** `docs/`. The workspace `docs/` is for cross-repo, public concerns only.
- If the just-written file violates either rule, undo it before the user sees it.

The hook is non-blocking and silently exits 0 on any error, so it can never fail a tool call. Emits both a `systemMessage` (UI) and `additionalContext` (agent context).

Also gitignores `.claude/settings.local.json` so personal permission allowlists don't get committed alongside the team-wide `.claude/settings.json`.

### 2. Hook hardening (`chore: harden workspace docs reminder hook`)
- `pwd -P` so a workspace cloned at a symlinked path matches the physical path the tool reports in `file_path`.
- Header comment documenting the `jq` dependency.
- Drop redundant `set +e`.

### 3. `./run install-dev-deps` (`feat(run): add install-dev-deps task`)
Installs the workspace-level dev dependencies — `jq` (used by the docs reminder hook), `lefthook` (pre-commit), `gh` (PR/CI ops) — via `brew` on macOS or `apt` on Debian/Ubuntu. Idempotent.

### 4. Docs cleanup (`docs: fix stale ./run command names in quickstart`)
The README and `AGENTS.md` quickstart blocks referenced `./run repos:clone`, `./run repos:pull-all-main`, and `./run repos:status` — none of which exist. Fixed to use the actual function names (`clone-repos`, `pull-all-main`, `show-status`). Also captures a pre-existing one-line `AGENTS.md` addition pointing contributors at `docs/solutions/`.

### Why this came together
We just hit a real instance of a private-repo plan landing in the public workspace `docs/` (PR #103, scrubbed in #104). The hook prevents a recurrence; the dependency it requires (`jq`) is now installable via the new `run` task; while looking at `run`, the stale README/AGENTS commands were noticed and fixed.

## Test plan
- [x] Pipe-tested the hook with five inputs: workspace `docs/` (fires), sub-repo `docs/` (skips), workspace non-docs (skips), relative path under `docs/` (fires), empty stdin (no-op, exit 0).
- [x] End-to-end: live `Write` to `docs/.hook-test-sentinel` triggered the hook in the implementing session — reminder appeared in the agent's context and the sentinel log captured the call. Test file deleted.
- [x] `jq -e` schema validation of `.claude/settings.json` passes.
- [x] `./run install-dev-deps` runs cleanly when all deps are already present (idempotent path).
- [x] `./run help` shows the new task under the "Setup" category.
- [x] No `repos:` references remain in `README.md` or `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)