### PR TITLE
docs(solutions): capture two learnings from CPT path-only Breaks PR

### DIFF
--- a/docs/solutions/best-practices/2026-04-30-skip-apt-depends-pins-sibling-halos-packages.md
+++ b/docs/solutions/best-practices/2026-04-30-skip-apt-depends-pins-sibling-halos-packages.md
@@ -115,6 +115,8 @@ The PR description carries the version requirement (`requires homarr-container-a
 
 ## Related
 
+- [`2026-05-13-prefer-breaks-over-depends-for-partial-upgrade-gating.md`](2026-05-13-prefer-breaks-over-depends-for-partial-upgrade-gating.md) — companion guidance: when this doc's Keep-the-pin conditions fire (silent failure mode OR manual partial upgrades are an expected operational pattern), reach for `Breaks: peer (<< X)` rather than `Depends: peer (>= X)`. PR halos-org/container-packaging-tools#203 is the worked example.
+- [`2026-05-13-shared-predicate-over-parallel-if-chains.md`](2026-05-13-shared-predicate-over-parallel-if-chains.md) — when a code generator auto-injects `Breaks:` lines (as CPT does for routed visible apps), the injection trigger must share its predicate with the contract-affected output trigger. Same review surfaced the drift.
 - `docs/plans/2026-04-29-001-feat-homarr-path-only-card-urls-plan.md` — the multi-PR plan whose implementation surfaced this question; Unit 5 covers the `cockpit.toml` change, and Unit 6 (the adapter migration with version probe) is the runtime-probe layer.
 - Workspace `AGENTS.md`, "APT Package Publishing Pipeline" section in MEMORY.md / "GitHub Organizations and APT Repositories" — describes the cohort-upgrade contract for `halos-org/apt.halos.fi` and `hatlabs/apt.hatlabs.fi`, which underwrites layer 1 of the test.
 - PR halos-org/halos-cockpit-config#30 — the concrete case where the pin was added per plan, then dropped after re-analysis.

--- a/docs/solutions/best-practices/2026-05-13-prefer-breaks-over-depends-for-partial-upgrade-gating.md
+++ b/docs/solutions/best-practices/2026-05-13-prefer-breaks-over-depends-for-partial-upgrade-gating.md
@@ -1,0 +1,128 @@
+---
+title: Prefer `Breaks: peer (<< X)` over `Depends: peer (>= X)` when gating against a partial-upgrade contract minimum
+date: 2026-05-13
+category: best-practices
+module: debian-packaging
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - A HaLOS package contract change requires a newer version of a sibling package
+  - The packages do not always upgrade in cohort (Cockpit App Store installs, manual `apt install <one-package>`, partial-upgrade scenarios)
+  - The consumer side fails silently when the contract is violated (the workspace policy doc names this as a Keep-the-pin condition)
+  - The peer is optional on devices that don't need the consumer surface (e.g., a marine device with container apps but no Homarr dashboard)
+  - Choosing between `Depends:` and `Breaks:` in `debian/control`
+tags:
+  - apt
+  - debian-packaging
+  - breaks
+  - depends-pin
+  - partial-upgrade
+  - package-coupling
+  - halos
+related:
+  - 2026-04-30-skip-apt-depends-pins-sibling-halos-packages.md
+---
+
+# Prefer `Breaks: peer (<< X)` over `Depends: peer (>= X)` when gating against a partial-upgrade contract minimum
+
+## Context
+
+[`2026-04-30-skip-apt-depends-pins-sibling-halos-packages.md`](2026-04-30-skip-apt-depends-pins-sibling-halos-packages.md) defines a three-layer test for when to drop a `Depends:` pin between sibling HaLOS packages (cohort upgrade + graceful skip + runtime probe — drop the pin if at least two are present). It also lists Keep-the-pin conditions: *"Failure mode is silent (data corruption, security bypass, irreversible migration)"* and *"Manual partial upgrades are an expected operational pattern."*
+
+The Keep clauses fire whenever a HaLOS package is installable à la carte — via the Cockpit App Store, a direct `apt install <one-package>`, or any flow that doesn't run a full `apt upgrade`. The original policy doc names the condition but stops short of recommending the Debian primitive that fits it. This doc is the companion: **when the Keep clauses fire, reach for `Breaks: peer (<< X)`, not `Depends: peer (>= X)`.**
+
+The two primitives produce very different behaviour for the same goal of "the contract requires peer ≥ X":
+
+| Primitive | When peer is installed at < X | When peer is installed at ≥ X | When peer is NOT installed |
+|---|---|---|---|
+| `Depends: peer (>= X)` | apt auto-upgrades the peer to satisfy | install succeeds | apt installs the peer first, even if the user didn't want it |
+| `Breaks: peer (<< X)` | apt auto-upgrades the peer to satisfy *or* refuses with a clear message | install succeeds | install succeeds — no constraint applies |
+
+The bottom-right cell is the decisive difference. `Depends:` over-constrains: a device that legitimately runs the producer without the consumer (e.g., Signal K-only marine box with no Homarr dashboard) is forced to install the consumer stack. `Breaks:` is conditional: it constrains the relationship only when the peer is already on the system. Debian Policy §7.4 documents `Breaks:` as exactly this — "this package cannot be installed at the same time as that older version of the named package."
+
+## Guidance
+
+**Use `Breaks: peer (<< MIN_VERSION)` when all of these are true:**
+
+1. The producer-side change forces a contract minimum on a sibling package.
+2. The sibling is operationally optional (some HaLOS variants don't ship it; users can install the producer without it).
+3. The packages are installable individually (Cockpit App Store, raw `apt install`, etc.).
+4. The consumer-side failure mode on contract violation is silent — a missing card, a dropped tile, a skipped registry entry — rather than a loud apt error.
+
+**Use `Depends: peer (>= MIN_VERSION)` only when** the sibling is part of the minimum HaLOS install on every device that uses this producer. If the peer is always present anyway, `Depends:` and `Breaks:` produce identical apt behaviour; prefer `Depends:` only because it documents the structural relationship more obviously to a reader of `debian/control`.
+
+**Use `Conflicts: peer` (no version) when** the relationship is fundamental incompatibility — two packages can never coexist regardless of version. `Conflicts:` is the wrong tool for a contract minimum because it would refuse the install forever, not just until the peer reaches the minimum.
+
+**When the trigger is generator-driven, inject the `Breaks:` automatically.** If a code generator emits the contract-affected output (e.g., `container-packaging-tools` writes the Debian control file), drive both the contract-affected output and the `Breaks:` injection from the same predicate. PR halos-org/container-packaging-tools#203 uses `registry.emits_path_only_url(metadata)` as the shared predicate — same function gates both the path-only URL emission and the Breaks injection, so they cannot drift. (See the companion learning [`2026-05-13-shared-predicate-over-parallel-if-chains.md`](2026-05-13-shared-predicate-over-parallel-if-chains.md).)
+
+## Why This Matters
+
+The Keep-the-pin Skip-Depends-pins doc names the condition this guidance addresses but doesn't disambiguate the available tools. Three concrete costs of getting it wrong:
+
+- **`Depends:` instead of `Breaks:`** forces the peer onto every device that touches the producer, even minimal installs. The peer's footprint (disk, services, attack surface) is now imposed system-wide. For HaLOS, this means a Signal K-only device gets the full Homarr stack just because it installed a Signal K plugin .deb.
+- **`Conflicts:` instead of `Breaks:`** permanently refuses co-installation. Apt cannot resolve it by upgrading the peer; the user is stuck. The relationship gets harder to evolve as the peer's release train moves forward.
+- **No constraint at all** (the pre-`Breaks:` state in PR #203) lets the install succeed onto a too-old peer. The consumer side encounters an unrecognised contract shape and fails silently — the failure is invisible to apt and to operators. This was the original silent missing-card bug that motivated this learning.
+
+`Breaks:` is the right tool because it matches the actual contract semantics: "older versions of peer cannot coexist with this version of producer." The peer's presence is independent; only the version relationship is constrained.
+
+## When to Apply
+
+Apply this when adding or revising a `debian/control` clause that pins a sibling HaLOS package's minimum version:
+
+- ✅ **Use `Breaks: peer (<< X)`** for partial-upgrade gating, contract minimums on optional peers, and any silent-failure mode.
+- ❌ **Skip the `Breaks:`** when all three Skip-Depends-pins conditions hold (cohort upgrade + graceful skip + runtime probe). The Skip-Depends-pins doc's three-layer test still applies; this guidance is what to use when that test fails.
+- ❌ **Don't use `Depends:`** for "minimum version of an optional peer." `Depends:` forces installation.
+- ❌ **Don't use `Conflicts:`** for "minimum version" relationships. `Conflicts:` is for fundamental incompatibility, not temporal contract drift.
+
+For generator-injected `Breaks:` (the producer's `debian/control` is generated, not hand-edited), drive the injection from the same predicate that triggers the contract-affected output. Don't duplicate the trigger condition in two places — see [`2026-05-13-shared-predicate-over-parallel-if-chains.md`](2026-05-13-shared-predicate-over-parallel-if-chains.md) for the failure mode and the fix.
+
+## Examples
+
+**Wrong — over-constraining `Depends:`** (hypothetical version of PR #203):
+
+```
+Package: marine-signalk-server-container
+Depends: ${misc:Depends},
+         docker-compose | docker-compose-plugin,
+         homarr-container-adapter (>= 0.4.6),
+         halos-core-containers (>= 0.3.2)
+```
+
+Installing this onto a Signal K-only device with no Homarr dashboard pulls in the entire Homarr stack — over-imposed footprint, services the user doesn't want running.
+
+**Right — conditional `Breaks:`** (what PR #203 actually does):
+
+```
+Package: marine-signalk-server-container
+Depends: ${misc:Depends}, docker-compose | docker-compose-plugin
+Breaks: homarr-container-adapter (<< 0.4.6),
+        halos-core-containers (<< 0.3.2)
+```
+
+Installing this onto a Signal K-only device: succeeds, no peer pulled in. Installing onto a device with `homarr-container-adapter 0.4.5`: apt either auto-upgrades the adapter to 0.4.6+ or refuses with `marine-signalk-server-container: Breaks: homarr-container-adapter (< 0.4.6) but 0.4.5-1 is installed`. Both outcomes are correct.
+
+**Generator-injected `Breaks:`** (the CPT v0.6.0 pattern). The Debian relationship string lives in one place — a generator helper consumed by every routed app's `debian/control` template:
+
+```python
+# In container-packaging-tools/src/generate_container_packages/template_context.py
+HOMARR_ADAPTER_MIN_VERSION = "0.4.6"
+HALOS_CORE_CONTAINERS_MIN_VERSION = "0.3.2"
+
+def _compute_homarr_stack_breaks(metadata):
+    if not emits_path_only_url(metadata):
+        return []
+    return [
+        f"homarr-container-adapter (<< {HOMARR_ADAPTER_MIN_VERSION})",
+        f"halos-core-containers (<< {HALOS_CORE_CONTAINERS_MIN_VERSION})",
+    ]
+```
+
+Bumping the contract minimum is one diff. Every CPT-generated .deb picks it up on the next rebuild.
+
+## Related
+
+- [Skip APT Depends pins between sibling HaLOS packages when graceful skip and cohort upgrade cover the failure mode](2026-04-30-skip-apt-depends-pins-sibling-halos-packages.md) — the policy doc this companion guidance extends. The Skip-Depends-pins doc names the Keep-the-pin conditions; this doc names the Debian primitive that fits them.
+- [Encode a shared decision in a shared predicate, not parallel if-chains with a "stay in lock-step" comment](2026-05-13-shared-predicate-over-parallel-if-chains.md) — when the `Breaks:` is generator-injected, this is how to keep the injection trigger aligned with the contract-affected output trigger.
+- Debian Policy Manual §7.4 — [Packages which break other packages](https://www.debian.org/doc/debian-policy/ch-relationships.html#packages-which-break-other-packages-breaks).
+- Worked example: [halos-org/container-packaging-tools#203](https://github.com/halos-org/container-packaging-tools/pull/203) — the CPT change that auto-injects `Breaks:` for routed visible apps.

--- a/docs/solutions/best-practices/2026-05-13-shared-predicate-over-parallel-if-chains.md
+++ b/docs/solutions/best-practices/2026-05-13-shared-predicate-over-parallel-if-chains.md
@@ -1,0 +1,199 @@
+---
+title: Encode a shared decision in a shared predicate, not parallel if-chains with a "stay in lock-step" comment
+date: 2026-05-13
+category: best-practices
+module: code-organization
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - Two or more call sites must answer the same question about the same input ("does this satisfy <condition>?")
+  - The condition is non-trivial — multiple fields, AND/OR logic, or domain-specific semantics
+  - The call sites live in different modules and can be modified independently
+  - The consequence of the predicates drifting is a silent failure rather than a loud one
+tags:
+  - code-organization
+  - shared-predicate
+  - drift
+  - silent-failure
+  - generator-pipelines
+  - halos
+related:
+  - 2026-05-13-prefer-breaks-over-depends-for-partial-upgrade-gating.md
+---
+
+# Encode a shared decision in a shared predicate, not parallel if-chains with a "stay in lock-step" comment
+
+## Context
+
+Two call sites need to answer the same question about the same input. Examples surface across the workspace:
+
+- A code generator's "emit shape A vs shape B" branch and a separate "register a constraint that only applies to shape A" branch.
+- A serializer's "include this field" decision and a validator's "require this field" decision on the same payload type.
+- A migration's "rewrite rows matching condition C" decision and a backfill's "include rows matching C" decision.
+
+The naïve implementation duplicates the condition at each site. The duplication is held together by maintainer discipline: a comment that says *"keep this in sync with X"*, or *"mirrors the precondition in Y"*, or *"the two stay in lock-step"*. A comment is not a contract. As soon as one site evolves without the other being updated, the two drift — and the failure mode is whatever the duplicated condition was guarding against.
+
+PR halos-org/container-packaging-tools#203 surfaced this pattern in the wild. The generator had two call sites asking the same question — *"does this app emit a path-only Homarr-card URL?"*:
+
+- `registry.generate_registry_toml` used the answer to pick the URL form (`/app_id/` vs `https://{{domain}}/app_id/`).
+- `template_context._compute_homarr_stack_breaks` used the answer to decide whether to inject Debian `Breaks:` clauses.
+
+Both implementations had a `routing is not None AND web_ui.enabled` shape. But the second one also gated on `web_ui.visible`. The first did not. The drift was 2-3 commits old; the CE review caught it before merge. The silent failure mode the drift exposed: a routed but hidden web app shipped a path-only TOML without the matching `Breaks:` line, so an older `homarr-container-adapter` would silently skip the TOML's ping-coverage entry with no apt-level signal to the operator.
+
+The plan's docstring on the duplicated function literally said *"the trigger condition mirrors `registry.generate_registry_toml`'s routed-branch precondition so the two stay in lock-step."* The comment had already failed.
+
+## Guidance
+
+**When two or more call sites answer the same non-trivial question about the same input, extract that question into a named predicate consumed by every site.**
+
+```python
+# Wrong — parallel if-chains, drift-prone, comment is the only safety net.
+
+# registry.py
+if routing is not None and web_ui.get("enabled"):
+    url = f"/{app_id}/"           # path-only form
+else:
+    url = f"https://{{domain}}/..."
+
+# template_context.py
+def _compute_homarr_stack_breaks(metadata):
+    if metadata.get("routing") is None: return []
+    if not (metadata.get("web_ui") or {}).get("enabled"): return []
+    if not (metadata.get("web_ui") or {}).get("visible"): return []   # <-- DRIFT
+    return [...]
+
+
+# Right — shared predicate, single source of truth.
+
+# registry.py
+def emits_path_only_url(metadata):
+    web_ui = metadata.get("web_ui") or {}
+    if not web_ui.get("enabled"): return False
+    if metadata.get("routing") is None: return False
+    return True
+
+def generate_registry_toml(metadata, ...):
+    ...
+    if emits_path_only_url(metadata):
+        url = f"/{app_id}/"
+    else:
+        ...
+
+# template_context.py
+from generate_container_packages.registry import emits_path_only_url
+
+def _compute_homarr_stack_breaks(metadata):
+    if not emits_path_only_url(metadata):
+        return []
+    return [...]
+```
+
+**Name the predicate after the question it answers, not after the answer it produces.** `emits_path_only_url(metadata)` reads as the question both call sites need answered. `is_routed_visible_web_app(metadata)` would be implementation-flavoured; `should_inject_homarr_breaks(metadata)` would couple to one of the two consumers.
+
+**Place the predicate near its primary semantic owner.** In PR #203 the path-only URL emission is the canonical surface (it determines the TOML content that all the other decisions key off); the predicate lives next to it in `registry.py`. The Breaks-injection site imports from there. The general rule: put the predicate where the most-load-bearing call site lives, then have other sites import from it.
+
+**Keep predicates pure.** No I/O, no logging, no side effects. The signature is `metadata -> bool`. Testing in isolation should be trivial — a single parameterised test feeding the full trigger matrix is the canonical coverage.
+
+## Why This Matters
+
+The cost of duplicating a non-trivial condition is paid silently and over time:
+
+- **Drift is invisible at write time.** When you copy a condition from one site to another, your assertion that they agree is correct *right then*. The drift accrues across subsequent commits that touch one site without the author noticing the other.
+- **Maintainer-discipline comments don't compose with reviews.** A reviewer looking at a one-site change won't see the duplicated site unless they grep for it. The "stay in lock-step" comment is invisible to the reviewer's tooling. PR #203's reviewer caught the drift only because they followed an explicit instruction to *verify the trigger condition mirrors the other site* — which is exactly the kind of high-cost manual check that a shared predicate eliminates.
+- **The failure mode is silent.** Drift produces incorrect output without any error. In PR #203, drift would have shipped routed-but-hidden web apps with no `Breaks:` line; the consequence on older adapters is a `tracing::warn` and a skipped registry entry. No apt error, no test failure, no log line in the producer.
+- **Future contract evolutions multiply the bookkeeping.** If the trigger condition gets a new clause (e.g., the contract needs to gate on `web_ui.path` as well), every duplicated site needs the new clause. A shared predicate absorbs the change in one place.
+
+The cost of extraction is negligible: one function definition, one import. The cost of *not* extracting is "the review catches the drift this time" — and you cannot rely on that catching it next time, when the reviewer's instructions are different.
+
+## When to Apply
+
+Apply this when **all three** signals are present:
+
+1. **Non-trivial condition.** The shared question involves at least 3 fields, or non-obvious AND/OR/negation logic, or domain-specific semantics ("is this a path-only URL emission?", "is this an enabled scheduled job that hasn't run yet?", "is this a public route under the auth boundary?"). A 1-2 field check (`if user.active and user.confirmed`) duplicated across two sites doesn't earn extraction.
+2. **Independent modification.** The call sites are in different modules, owned by potentially different reviewers, modifiable in separate PRs. If the two sites are 30 lines apart in the same function, duplication is fine — drift is unlikely.
+3. **Silent failure on drift.** The consequence of the predicates returning different answers is incorrect output, not a loud error. If drift would produce a `ValueError` or a failing test, drift will surface on its own and you don't need preemptive extraction.
+
+**Don't apply when:**
+
+- The two call sites are tightly co-located (same function, same module section).
+- The condition is structurally similar but semantically different (one site asks "is the user authenticated?", the other asks "is the request from an authenticated user?" — these can drift correctly).
+- The "shared" appearance is incidental (today's two sites happen to use the same fields, but the contract for each is independent and could legitimately diverge).
+- Extraction would require a new module with no other content — wait until a second extraction earns the boundary.
+
+**Signal to grep for:** comments in your own code containing *"keep in sync with"*, *"mirrors X"*, *"must match Y"*, *"the two stay in lock-step"*. Each one is a duplicated decision that the author already recognised as drift-prone. Treat the comment as a TODO to extract.
+
+## Examples
+
+**The drift caught in PR #203.** Before extraction:
+
+```python
+# src/generate_container_packages/registry.py — the path-only branch
+if routing is not None:
+    url = f"/{app_id}/"                # only checks routing + enabled (via outer guard)
+
+# src/generate_container_packages/template_context.py — the Breaks injection
+def _compute_homarr_stack_breaks(metadata):
+    if metadata.get("routing") is None: return []
+    if not web_ui.get("enabled"): return []
+    if not web_ui.get("visible"): return []   # <-- drifts from registry.py
+    return [...]
+```
+
+A routed app with `web_ui.visible: false` ships a path-only TOML (per `registry.py`'s decision) but no `Breaks:` line (per the `_compute_homarr_stack_breaks` gate). On an older `homarr-container-adapter` the TOML's URL fails validation and the entry is skipped silently — ping coverage for that app is broken with no signal.
+
+**After extraction:**
+
+```python
+# src/generate_container_packages/registry.py
+def emits_path_only_url(metadata):
+    """Single source of truth — both URL emission and Breaks injection key off this."""
+    web_ui = metadata.get("web_ui") or {}
+    if not web_ui.get("enabled"): return False
+    if metadata.get("routing") is None: return False
+    return True
+
+def generate_registry_toml(metadata, ...):
+    if emits_path_only_url(metadata):
+        url = f"/{app_id}/"
+    else:
+        url = f"https://{{domain}}/..."
+
+# src/generate_container_packages/template_context.py
+from generate_container_packages.registry import emits_path_only_url
+
+def _compute_homarr_stack_breaks(metadata):
+    if not emits_path_only_url(metadata):
+        return []
+    return [...]
+```
+
+The two sites cannot drift. A future contract evolution adding a new clause (e.g., a path-only emission for some `web_ui.path` shape) is a single diff. The original docstring comment ("mirrors registry.generate_registry_toml's routed-branch precondition") becomes unnecessary — the predicate *is* the contract.
+
+**The general shape.** Any time you have:
+
+```python
+# Module A
+if (cond1 and cond2 and not cond3):
+    do_A_thing()
+
+# Module B — must agree
+def should_B_thing(input):
+    return cond1 and cond2 and not cond3   # comment: "keep in sync with A"
+```
+
+Extract:
+
+```python
+# Module shared (or wherever the most load-bearing site lives)
+def is_<the_question>(input):
+    return cond1 and cond2 and not cond3
+```
+
+…and have both A and B call it. Then write the test that exercises the predicate's truth table once, not the call sites.
+
+## Related
+
+- [Prefer `Breaks: peer (<< X)` over `Depends: peer (>= X)` when gating against a partial-upgrade contract minimum](2026-05-13-prefer-breaks-over-depends-for-partial-upgrade-gating.md) — when a code generator auto-injects `Breaks:`, the injection trigger must share its predicate with the contract-affected output trigger. This learning is the structural pattern that makes that sharing safe.
+- Worked example: [halos-org/container-packaging-tools#203](https://github.com/halos-org/container-packaging-tools/pull/203) — the CPT change where CE review caught the predicate drift and the fix extracted `registry.emits_path_only_url`.
+- Related cross-repo learning ([halos-org/homarr-container-adapter](https://github.com/halos-org/homarr-container-adapter/blob/main/docs/solutions/best-practices/2026-05-04-ship-cross-format-identity-helper-before-url-migration.md)): when a contract shape changes, the consumer must accept both shapes during the transition. Both are forms of "encode contract semantics in one place, not many."


### PR DESCRIPTION
Two new best-practices docs distilled from [halos-org/container-packaging-tools#203](https://github.com/halos-org/container-packaging-tools/pull/203) (which adds conditional Debian `Breaks:` auto-injection to CPT-generated .debs for routed visible web apps). Plus bidirectional cross-references in the pre-existing [`2026-04-30-skip-apt-depends-pins-sibling-halos-packages.md`](https://github.com/halos-org/halos/blob/main/docs/solutions/best-practices/2026-04-30-skip-apt-depends-pins-sibling-halos-packages.md) policy doc.

## What's added

### `2026-05-13-prefer-breaks-over-depends-for-partial-upgrade-gating.md`

Companion to the 2026-04-30 Skip-Depends-pins policy. That doc names the Keep-the-pin conditions (silent failure mode, manual partial upgrades are an expected operational pattern) but doesn't recommend a Debian primitive. This doc says: when those conditions fire, use `Breaks: peer (<< X)`, not `Depends: peer (>= X)`. `Breaks` is conditional on the peer being installed — it doesn't over-constrain devices that don't ship the peer at all. Includes the apt resolver behaviour matrix (`Breaks` vs `Depends` vs `Conflicts`), a worked wrong/right example pulled from PR #203, and the generator-injection pattern.

### `2026-05-13-shared-predicate-over-parallel-if-chains.md`

General code-organisation pattern surfaced during PR #203's CE review. When two call sites must answer the same non-trivial question about the same input, extract a named predicate. Maintainer-discipline comments like "keep this in sync with X" or "the two stay in lock-step" aren't contracts — they fail silently when one site evolves. PR #203's pre-review state had the path-only-emission trigger duplicated between `registry.py` and `template_context.py` with exactly such a comment. The fix extracted `registry.emits_path_only_url` as the shared source of truth. Doc covers when to apply (and when not to — caveats included).

### Cross-references in `2026-04-30-skip-apt-depends-pins-sibling-halos-packages.md`

Two new lines added to the Related section pointing forward to the new docs. Future PR authors hitting the partial-upgrade pin question will land on whichever angle fits their context first.

## Cross-repo nature

Both learnings are cross-repo (Debian packaging hygiene + general code-organisation pattern), so they belong in the workspace, alongside the existing 2026-04-30 doc — not in any individual repo. The workspace `AGENTS.md` already surfaces `docs/solutions/` to agents, so discoverability is intact.