### PR TITLE
docs: remove archived halos-mdns-publisher from structure lists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,6 @@ halos/
 ├── halos-homarr-branding/         # Homarr HaLOS branding package
 ├── halos-imported-containers/     # Auto-imported apps from CasaOS, Runtipi, etc.
 ├── halos-marine-containers/       # Marine app definitions + store
-├── halos-mdns-publisher/          # mDNS hostname publisher daemon
 ├── halos-metapackages/            # HaLOS metapackages (halos, halos-marine)
 ├── homarr-container-adapter/      # Homarr first-boot setup and container discovery
 ├── opencpn-docker/                # OpenCPN Docker image

--- a/README.md
+++ b/README.md
@@ -263,7 +263,6 @@ This repository acts as a workspace manager for all the components that make up 
 - **halos-homarr-branding/** - Homarr HaLOS branding package
 - **halos-imported-containers/** - Auto-imported apps from CasaOS, Runtipi, etc.
 - **halos-marine-containers/** - Marine app definitions and store configuration
-- **halos-mdns-publisher/** - mDNS hostname publisher daemon
 - **halos-metapackages/** - Halos and Halos-Marine metapackages
 - **homarr-container-adapter/** - Homarr first-boot setup and container discovery
 - **opencpn-docker/** - OpenCPN Docker image


### PR DESCRIPTION
## Summary
- Removes the `halos-mdns-publisher/` entry from the Structure list in `AGENTS.md` (the line called out in the issue).
- Removes the parallel `halos-mdns-publisher/` line in `README.md`'s Structure section — same stale pattern, same compounding-cost justification. Calling it out explicitly so reviewers can scope it down to just AGENTS.md if preferred.
- Leaves `docs/HOSTNAME_POLICY.md:118` alone: that table is a historical audit of where mDNS-era hostname violations were found, not a structure list. Different context.

## Why
The multi-level mDNS subdomain approach was retired in favor of path-based routing and the multi-hostname plan (already implemented in `halos-core-containers`). The `halos-mdns-publisher` repo is archived. Continuing to list it in workspace structure docs misleads readers — human and AI — into reasoning about a feature that no longer exists.

## Out of scope (per issue)
- Wider `AGENTS.md` Structure vs. `./run` REPOS map divergence audit (Structure lists 19, REPOS lists 11). Flagged in the issue for follow-up.
- The container-packaging-tools cleanup tracked in halos-org/container-packaging-tools#204 (handled separately).

Refs halos-org/halos#111