### PR TITLE
docs(AGENTS): VERSION bumps are per release cycle, not per PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ This workspace manages multiple independent repositories. While each repository 
 
 **Changelog Policy**: Never edit `debian/changelog` files directly. Always use `./run bumpversion` which uses the `dch` tool for proper RFC 2822 date formatting. Direct edits cause weekday/date mismatches that break Debian tools. See individual repository AGENTS.md for details.
 
-**Version Bumps**: PRs that change package-affecting files must include a version bump. CI enforces this — see each repository's version management docs for how to bump. Docs, tests, CI config, and dev tooling changes are automatically excluded.
+**Version Bumps**: VERSION bumps are *per release cycle*, not per PR. Default: do NOT bump `VERSION` in feature PRs — CI auto-increments the `+N` revision in release tags (e.g., `v0.3.2+1`, `+2`, `+3`) between stable releases. Bump `VERSION` only when starting a new release cycle, i.e., when `VERSION` currently matches the latest stable tag and this PR is opening the next cycle. If `VERSION` already differs from the latest stable tag (a prior PR opened the cycle), no further bump is needed regardless of how many package-affecting files this PR touches. App-level versions in `apps/*/metadata.yaml` (container repos) bump per PR independently. CI enforces both rules conditionally — see `shared-workflows/.github/workflows/version-bump-check.yml`. Docs, tests, CI config, and dev tooling changes are excluded from the repo-level check.
 
 ## Structure
 


### PR DESCRIPTION
## Summary

Rewrite the "Version Bumps" line in workspace `AGENTS.md` to lead with the default-no-bump rule. This is the source-of-truth wording for the realignment tracked in #113.

## Why

The CI rule in `shared-workflows/version-bump-check.yml` has always been conditional (bump only when `VERSION == latest stable tag`). The workspace doc said "PRs that change package-affecting files must include a version bump" — flat and wrong — which trained contributors to bump in every feature PR, leaving gaps in the stable release history (e.g., `halos-core-containers` v0.3.3 was bumped, tagged as prerelease, and never shipped).

The gold-standard counter-example is `halos-marine-containers`: a single `VERSION` of `0.3.2` has shipped twelve `+N` prereleases.

## Test plan

- [ ] Workspace docs reads as the source of truth that the per-repo `AGENTS.md` pointers refer to.

Refs halos-org/halos#113