### PR TITLE
docs(agents): codify worktree location convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,10 @@ Decision procedure for a feature PR:
 
 "Package-affecting" means any file that ends up in a `.deb` — everything except docs, tests, CI config, and dev tooling. The exact set is non-obvious (root `docker-compose.yml` is payload for container repos and counts; `run`, `Makefile`, `tools/`, `store/`, `docker/`, and lockfiles do not), so treat `shared-workflows/.github/workflows/version-bump-check.yml` as the source of truth. Per-repo changelog schemes differ (committed vs CI-generated `debian/changelog`); see each repo's AGENTS.md.
 
+## Worktree Location
+
+Git worktrees live in a hidden `.worktrees/` directory **inside the clone they belong to**, at `<repo>/.worktrees/<branch>` — keeping each worktree co-located with its own repo. Never create them as siblings inside this workspace (e.g. a `skip-203/` next to `skip/`): this workspace root is itself a git repo, so a sibling shows up as untracked clutter in its `git status`, belongs to no repo in anyone's mental model, and rots unnoticed. Keep `.worktrees/` gitignored so it never clutters the owning repo's status either. Use the `git-worktree` skill, which defaults to this location; don't hand-run `git worktree add ../<name>`. The Agent tool's transient `<repo>/.claude/worktrees/agent-*` worktrees follow the same in-clone pattern and self-clean.
+
 ## Structure
 
 ```


### PR DESCRIPTION
## Motivation

A cleanup sweep found 10 stale git worktrees scattered across three ad-hoc locations: broken ones under `~/.claude-worktrees/halos-distro/` (pointing at the pre-rename repo path), and — the real problem — seven `skip-*` worktrees created as **siblings inside this workspace root**. Because the workspace root is itself a git repo, those siblings showed up as untracked clutter in its `git status`, belonged to no repo in anyone's mental model, and sat unnoticed for months (some merged back in December).

There was no documented convention for where worktrees go, so each tool and session picked its own.

## Change

Add a `## Worktree Location` section to the workspace `AGENTS.md` standardizing on a hidden `.worktrees/` directory **inside the clone each worktree belongs to** (`<repo>/.worktrees/<branch>`). This keeps repo/worktree affinity, matches the `git-worktree` skill's existing default (`$GIT_ROOT/.worktrees`), and — because `.worktrees/` is gitignored — keeps both the workspace root and the owning repo's `git status` clean. The prohibition that actually mattered stays: never create worktrees as siblings inside the workspace root. The Agent tool's transient `<repo>/.claude/worktrees/agent-*` worktrees follow the same in-clone pattern and self-clean.

Documentation only; no code or build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)